### PR TITLE
Adjust timer for OS X

### DIFF
--- a/include/rabit/timer.h
+++ b/include/rabit/timer.h
@@ -8,14 +8,47 @@
 #include <time.h>
 #include "./utils.h"
 
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#define ORWL_NANO (+1.0E-9)
+#define ORWL_GIGA UINT64_C(1000000000)
+
+static double orwl_timebase = 0.0;
+static uint64_t orwl_timestart = 0;
+#endif  /* __APPLE__ */
+
 namespace rabit {
 namespace utils {
+    
+#ifdef __APPLE__
+    /* OS X replacement coded by Jens Gustedt,
+       http://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x  */
+    struct timespec clock_gettime(void) {
+        if (!orwl_timestart) {
+            mach_timebase_info_data_t tb = { 0 };
+            mach_timebase_info(&tb);
+            orwl_timebase = tb.numer;
+            orwl_timebase /= tb.denom;
+            orwl_timestart = mach_absolute_time();
+        }
+        struct timespec t;
+        double diff = (mach_absolute_time() - orwl_timestart) * orwl_timebase;
+        t.tv_sec = diff * ORWL_NANO;
+        t.tv_nsec = diff - (t.tv_sec * ORWL_GIGA);
+        return t;
+    }
+#endif
+
 /*!
  * \brief return time in seconds, not cross platform, avoid to use this in most places
  */
 inline double GetTime(void) {
   timespec ts;
+#ifdef __APPLE__
+    ts = clock_gettime();
+#else
   utils::Check(clock_gettime(CLOCK_REALTIME, &ts) == 0, "failed to get time");
+#endif
   return static_cast<double>(ts.tv_sec) + static_cast<double>(ts.tv_nsec) * 1e-9;
 }
 }


### PR DESCRIPTION
Building the current master causes this error on OS X Yosemite:

    c++ -c -O3 -msse2 -fPIC -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -pedantic   -o engine_mock.o src/engine_mock.cc
    In file included from src/engine_mock.cc:14:
    In file included from src/./allreduce_mock.h:14:
    src/../include/rabit/timer.h:18:30: error: use of undeclared identifier
          'CLOCK_REALTIME'
      utils::Check(clock_gettime(CLOCK_REALTIME, &ts) == 0, "failed to get time");
                             ^
    1 error generated.
    make: *** [engine_mock.o] Error 1

I've dropped in a fix, based on a [Stack Overflow answer](http://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x). Not sure if there are any particular ways I should test it, but I can run the speed_test in rabit, and also build and use xgboost. (Thanks for xgboost, by the way; very nice!)
